### PR TITLE
Bug fix for iteracting with agents with no memories

### DIFF
--- a/genagents/modules/interaction.py
+++ b/genagents/modules/interaction.py
@@ -34,6 +34,9 @@ def _utterance_agent_desc(agent, anchor):
   agent_desc += f"Other observations about the subject:\n\n"
 
   retrieved = agent.memory_stream.retrieve([anchor], 0, n_count=120)
+  if len(retrieved) == 0:
+    return agent_desc
+  
   nodes = list(retrieved.values())[0]
   for node in nodes:
     agent_desc += f"{node.content}\n"

--- a/genagents/modules/memory_stream.py
+++ b/genagents/modules/memory_stream.py
@@ -218,6 +218,7 @@ def extract_recency(seq_nodes):
     recency_out: A dictionary whose keys are the node.node_id and whose values
                  are the float that represents the recency score. 
   """
+  
   max_timestep = max([node.last_retrieved for node in seq_nodes])
 
   recency_decay = 0.99
@@ -361,6 +362,10 @@ class MemoryStream:
         values are a list of nodes that are retrieved for that query str. 
     """
     curr_nodes = []
+
+    # If the memory stream is empty, we return an empty dictionary.
+    if len(self.seq_nodes) == 0:
+      return dict()
 
     # Filtering for the desired node type. curr_filter can be one of the three
     # elements: 'all', 'reflection', 'observation' 

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ class Conversation:
 # Example usage:
 if __name__ == "__main__":
   # Specify the folder where the agent is stored
-  agent_folder = "agent_bank/populations/sample_agent/01fd7d2a-0357-4c1b-9f3e-8eade2d537ae"
+  agent_folder = "agent_bank/populations/single_agent/01fd7d2a-0357-4c1b-9f3e-8eade2d537ae"
   # Create a Conversation instance
   conversation = Conversation(agent_folder, interviewer_name="Jane Doe")
   # Start the conversation


### PR DESCRIPTION
When using agents with no existing memories (e.g., all of the GSS agents), an error occurs in the memory retrieval function if an utterance/response function is used before memories are added with remember(). This fix checks for empty memory streams, fixing the bug. Additionally, there is a correction to the file path for the demo agent in main.py